### PR TITLE
Passing through arguments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, mbstring, zip, fileinfo, pdo_sqlite  # Added pdo_sqlite
+          extensions: dom, intl, mbstring, zip, fileinfo, pdo_sqlite  # Added pdo_sqlite
           coverage: none
 
       - name: Get Composer cache directory

--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ This package lets you `benchmark` your artisan commands:
 php artisan benchmark your:command
 ```
 
-Simply replace `⁠your:command` with your command signature. After execution, you'll see detailed benchmark results.
+Simply replace `⁠your:command` with your command signature.
 
+To provide arguments and options, use quotes to wrap the command signature:
+
+```shell
+php artisan benchmark "your:command --with-option"
+```
+
+After execution, you'll see detailed benchmark results.
 
 ![CleanShot 2025-02-08 at 17 56 49@2x](https://github.com/user-attachments/assets/d5a6e86d-1cc4-4786-b246-3c8939aec053)
 

--- a/src/Console/ArtisanBenchmarkCommand.php
+++ b/src/Console/ArtisanBenchmarkCommand.php
@@ -10,9 +10,4 @@ class ArtisanBenchmarkCommand extends Command
     use BenchmarksArtisanCommand;
 
     protected $signature = 'benchmark {signature?} {--tableToWatch=}';
-
-    public function handleWithBenchmark(): void
-    {
-        $this->call($this->argument('signature'));
-    }
 }

--- a/tests/Commands/TestWithArgumentsCommand.php
+++ b/tests/Commands/TestWithArgumentsCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use Illuminate\Console\Command;
+
+class TestWithArgumentsCommand extends Command
+{
+    protected $signature = '
+        with-arguments:test
+        {custom-argument}
+        {--custom-option}
+        {--C|custom-option-with-shortcut}
+        {--custom-option-with-value=}
+        {--custom-option-array=*}
+    ';
+
+    public function handle(): void
+    {
+        $this->line('Custom argument: '.$this->argument('custom-argument'));
+        $this->line('Custom option: '.$this->option('custom-option'));
+        $this->line('Custom option with shortcut: '.$this->option('custom-option-with-shortcut'));
+        $this->line('Custom option with value: '.$this->option('custom-option-with-value'));
+        $this->line('Custom option array: '.implode(', ', $this->option('custom-option-array')));
+    }
+}

--- a/tests/Feature/ArtisanBenchmarkCommandTest.php
+++ b/tests/Feature/ArtisanBenchmarkCommandTest.php
@@ -1,9 +1,13 @@
 <?php
 
 use ChristophRumpel\ArtisanBenchmark\Console\ArtisanBenchmarkCommand;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Facades\Artisan;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Tests\Commands\TestImportCommand;
+use Tests\Commands\TestWithArgumentsCommand;
 
 test('it can benchmark an artisan command with explicit signature', function () {
     // Act
@@ -15,6 +19,85 @@ test('it can benchmark an artisan command with explicit signature', function () 
         ->toContain('TIME:')
         ->toContain('MEM:')
         ->toContain('SQL: 0');
+});
+
+test('it can benchmark an artisan command with arguments passed through', function () {
+    // Arrange
+    app(Kernel::class)->registerCommand(new TestWithArgumentsCommand);
+
+    // Act
+    Artisan::call(
+        ArtisanBenchmarkCommand::class,
+        [
+            'signature' => 'with-arguments:test',
+            'custom-argument' => true,
+            '--custom-option' => true,
+            '--custom-option-with-shortcut' => true,
+            '--custom-option-with-value' => 1,
+            '--custom-option-array' => [1, 2],
+        ]
+    );
+
+    $output = Artisan::output();
+
+    // Assert
+    expect($output)
+        ->toContain('Custom argument: 1')
+        ->toContain('Custom option: 1')
+        ->toContain('Custom option with shortcut: 1')
+        ->toContain('Custom option with value: 1')
+        ->toContain('Custom option array: 1, 2');
+});
+
+test('it can benchmark an artisan command with arguments passed through as string', function () {
+    // Arrange
+    app(Kernel::class)->registerCommand(new TestWithArgumentsCommand);
+
+    $input = new StringInput('
+        benchmark
+        with-arguments:test
+        1
+        --custom-option
+        -C
+        --custom-option-with-value=1
+        --custom-option-array=1
+        --custom-option-array=2
+    ');
+
+    // Act
+    Artisan::handle($input, $output = new BufferedOutput);
+
+    // Assert
+    expect($output->fetch())
+        ->toContain('Custom argument: 1')
+        ->toContain('Custom option: 1')
+        ->toContain('Custom option with shortcut: 1')
+        ->toContain('Custom option with value: 1')
+        ->toContain('Custom option array: 1, 2');
+});
+
+test('it can benchmark an artisan command with arguments mixed with tableToWatch option', function () {
+    // Arrange
+    $this->loadLaravelMigrations();
+
+    app(Kernel::class)->registerCommand(new TestWithArgumentsCommand);
+
+    $input = new StringInput('
+        benchmark
+        --tableToWatch=users
+        with-arguments:test
+        1
+        --custom-option
+    ');
+
+    // Act
+    Artisan::handle($input, $output = new BufferedOutput);
+
+    // Assert
+    expect($output->fetch())
+        ->toContain('Custom argument: 1')
+        ->toContain('Custom option: 1')
+        ->toContain('ROWS: 0');
 });
 
 test('it asks for command selected from a list', function () {

--- a/tests/Feature/ArtisanBenchmarkCommandTest.php
+++ b/tests/Feature/ArtisanBenchmarkCommandTest.php
@@ -29,12 +29,15 @@ test('it can benchmark an artisan command with arguments passed through', functi
     Artisan::call(
         ArtisanBenchmarkCommand::class,
         [
-            'signature' => 'with-arguments:test',
-            'custom-argument' => true,
-            '--custom-option' => true,
-            '--custom-option-with-shortcut' => true,
-            '--custom-option-with-value' => 1,
-            '--custom-option-array' => [1, 2],
+            'signature' => <<<'SIGNATURE'
+                with-arguments:test
+                1
+                --custom-option
+                -C
+                --custom-option-with-value=1
+                --custom-option-array=1
+                --custom-option-array=2
+            SIGNATURE,
         ]
     );
 
@@ -42,33 +45,6 @@ test('it can benchmark an artisan command with arguments passed through', functi
 
     // Assert
     expect($output)
-        ->toContain('Custom argument: 1')
-        ->toContain('Custom option: 1')
-        ->toContain('Custom option with shortcut: 1')
-        ->toContain('Custom option with value: 1')
-        ->toContain('Custom option array: 1, 2');
-});
-
-test('it can benchmark an artisan command with arguments passed through as string', function () {
-    // Arrange
-    app(Kernel::class)->registerCommand(new TestWithArgumentsCommand);
-
-    $input = new StringInput('
-        benchmark
-        with-arguments:test
-        1
-        --custom-option
-        -C
-        --custom-option-with-value=1
-        --custom-option-array=1
-        --custom-option-array=2
-    ');
-
-    // Act
-    Artisan::handle($input, $output = new BufferedOutput);
-
-    // Assert
-    expect($output->fetch())
         ->toContain('Custom argument: 1')
         ->toContain('Custom option: 1')
         ->toContain('Custom option with shortcut: 1')
@@ -85,9 +61,7 @@ test('it can benchmark an artisan command with arguments mixed with tableToWatch
     $input = new StringInput('
         benchmark
         --tableToWatch=users
-        with-arguments:test
-        1
-        --custom-option
+        "with-arguments:test 1 --custom-option"
     ');
 
     // Act


### PR DESCRIPTION
This tool is great!

I just needed it to be able to pass the arguments & options through.

Now using the signature in a string as suggested by @christophrumpel :)

Example usage:

```bash
# as before
artisan benchmark import:users

# with arguments and options
artisan benchmark "import:users --force"

# mixed with benchmark command's options
artisan benchmark --tableToWatch=users "import:users --force"
```